### PR TITLE
Fixed spread not applying on bow Power Shot 3

### DIFF
--- a/src/data/attacks/bow.ts
+++ b/src/data/attacks/bow.ts
@@ -49,6 +49,7 @@ export const BowAttacks = [
     eleMul: 0.6,
     hits: 5,
     rawMul: 1.1,
+    spreadPowerShot: true,
   },
   {
     name: "Flying Swallow Shot Lv1",


### PR DESCRIPTION
This move was mismarked as not applying for spread decorations.
Tested in training area with YKK (no coatings) - Normal Power Shot Lvl3 outputs 25.5 per arrow. With Spread jewel, Power Shot Lvl3 outputs 26.5 per arrow.